### PR TITLE
v1.1.0

### DIFF
--- a/requirements-test-lock.txt
+++ b/requirements-test-lock.txt
@@ -1,5 +1,5 @@
 aiosqlite==0.17.0
-asgiar==0.2.0
+asgiar==0.2.1
 attrs==21.2.0
 bmt-lite-1.8.2==1.1.0
 certifi==2021.5.30

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,7 +4,7 @@ reasoner-pydantic==1.1.2.1
 uvicorn==0.11.7
 python-dotenv==0.17.0
 
-asgiar==0.2.0
+asgiar==0.2.1
 pytest==5.4.3
 pytest-asyncio==0.14.0
 pytest-cov==2.10.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="trapi-throttle",
-    version="1.0.0",
+    version="1.1.0",
     author="Patrick Wang",
     author_email="patrick@covar.com",
     url="https://github.com/ranking-agent/trapi-throttle",

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -307,6 +307,38 @@ async def test_slow():
     response={"message": {
         "knowledge_graph": {"nodes": {}, "edges": {}},
         "query_graph": QG,
+        "results": [],
+    }},
+    request_qty=5,
+    request_duration=datetime.timedelta(seconds=1),
+    delay=10.0,
+)
+async def test_batched_timeout():
+    """Test KP/batched-level timeout."""
+    kp_info = {
+        "url": "http://kp1/query",
+        "request_qty": 1,
+        "request_duration": 0.75,
+    }
+
+    with pytest.raises(asyncio.exceptions.TimeoutError):
+        async with ThrottledServer(
+            "kp1",
+            **kp_info,
+            timeout=1.0,
+        ) as server:
+            await server.query(
+                {"message": {"query_graph": QG}},
+                timeout=None,
+            )
+
+
+@pytest.mark.asyncio
+@with_response_overlay(
+    "http://kp1/query",
+    response={"message": {
+        "knowledge_graph": {"nodes": {}, "edges": {}},
+        "query_graph": QG,
         "results": None,
     }},
     request_qty=5,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 from collections import defaultdict
 from contextlib import asynccontextmanager, AsyncExitStack
 from urllib.parse import urlparse
@@ -61,7 +62,8 @@ async def response_overlay(
         url,
         response: Response,
         request_qty: int,
-        request_duration: datetime.timedelta
+        request_duration: datetime.timedelta,
+        delay: float = 0.0,
 ):
     """
     Create a router that returns the specified
@@ -74,6 +76,7 @@ async def response_overlay(
         # pylint: disable=unused-variable disable=unused-argument
         @app.api_route('/{path:path}', methods=["GET", "POST", "PUT", "DELETE"])
         async def all_paths(path):
+            await asyncio.sleep(delay)
             return response
 
         app.add_middleware(

--- a/trapi_throttle/server.py
+++ b/trapi_throttle/server.py
@@ -1,6 +1,4 @@
 """Server routes"""
-import asyncio
-import datetime
 from functools import wraps
 from json.decoder import JSONDecodeError
 import logging

--- a/trapi_throttle/throttle.py
+++ b/trapi_throttle/throttle.py
@@ -64,7 +64,9 @@ class ThrottledServer():
         # This is an implementation of the GCRA algorithm
         # More information can be found here:
         # https://dev.to/astagi/rate-limiting-using-python-and-redis-58gk
-        tat = datetime.datetime.utcnow()
+        if self.request_qty > 0:
+            interval = self.request_duration / self.request_qty
+            tat = datetime.datetime.utcnow() + interval
 
         while True:
             # Get everything in the stream or wait for something to show up
@@ -201,8 +203,7 @@ class ThrottledServer():
                     await asyncio.sleep(time_remaining_seconds)
 
                 # Update TAT
-                interval = self.request_duration / self.request_qty
-                tat = (datetime.datetime.utcnow() + interval)
+                tat = datetime.datetime.utcnow() + interval
 
     async def __aenter__(
             self,

--- a/trapi_throttle/throttle.py
+++ b/trapi_throttle/throttle.py
@@ -247,7 +247,7 @@ class ThrottledServer():
     async def query(
             self,
             query: dict,
-            timeout: float = 60.0,
+            timeout: Optional[float] = 60.0,
     ) -> dict:
         """ Queue up a query for batching and return when completed """
         if self.worker is None:

--- a/trapi_throttle/throttle.py
+++ b/trapi_throttle/throttle.py
@@ -232,6 +232,7 @@ class ThrottledServer():
     async def query(
             self,
             query: dict,
+            timeout: float = 60.0,
     ) -> dict:
         """ Queue up a query for batching and return when completed """
         if self.worker is None:
@@ -244,7 +245,10 @@ class ThrottledServer():
         await self.request_queue.put((request_id, query, response_queue))
 
         # Wait for response
-        output: Union[dict, Exception] = await response_queue.get()
+        output: Union[dict, Exception] = await asyncio.wait_for(
+            response_queue.get(),
+            timeout=timeout,
+        )
 
         if isinstance(output, Exception):
             raise output

--- a/trapi_throttle/trapi.py
+++ b/trapi_throttle/trapi.py
@@ -98,7 +98,7 @@ def filter_by_curie_mapping(
     # Only keep results where there is a node binding
     # that connects to our given kgraph_node_id
     message["results"] = [
-        result for result in message["results"]
+        result for result in (message["results"] or [])
         if result_contains_node_bindings(result, curie_mapping)
     ]
 

--- a/trapi_throttle/trapi.py
+++ b/trapi_throttle/trapi.py
@@ -83,11 +83,13 @@ def filter_by_curie_mapping(
     contain the bindings specified in the curie_mapping
     """
     message = copy.deepcopy(message)
+    if message["query_graph"] is None:
+        raise BatchingError(f"qgraph not returned from {kp_id}")
+    if message["knowledge_graph"] is None:
+        raise BatchingError(f"kgraph not returned from {kp_id}")
 
     # Update query graph IDs
     for qg_id, curie_list in curie_mapping.items():
-        if message["query_graph"] is None:
-            raise BatchingError(f"qgraph not returned from {kp_id}")
         try:
             message["query_graph"]["nodes"][qg_id]["ids"] = curie_list
         except KeyError:

--- a/trapi_throttle/trapi.py
+++ b/trapi_throttle/trapi.py
@@ -11,7 +11,7 @@ class UnableToMerge(BaseException):
     """ Unable to merge given query graphs """
 
 
-def extract_curies(qgraph: QueryGraph) -> dict[str, list[str]]:
+def get_curies(qgraph: QueryGraph) -> dict[str, list[str]]:
     """
     Pull curies from query graph and
     return them as a mapping of node_id -> curie_list
@@ -21,6 +21,16 @@ def extract_curies(qgraph: QueryGraph) -> dict[str, list[str]]:
         for node_id, node in qgraph["nodes"].items()
         if (curies := node.get("ids", None)) is not None
     }
+
+
+def remove_curies(qgraph: QueryGraph) -> dict[str, list[str]]:
+    """
+    Remove curies from query graph.
+    """
+    qgraph = copy.deepcopy(qgraph)
+    for node in qgraph["nodes"].values():
+        node.pop("ids", None)
+    return qgraph
 
 
 def remove_unbound_from_kg(message):


### PR DESCRIPTION
Bug fixes:
* Fix batching to aggregate when only qnode ids differ
* Handle responses missing QG/KG better

Features:
* Add optional timeout to `query()`
* Add optional timeout to batched queries
* Retry KP requests on 429 responses